### PR TITLE
shoot kube-state-metrics collect more resources metrics

### DIFF
--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         - /kube-state-metrics
         - --port=8080
         - --telemetry-port=8081
+        - --collectors=daemonsets,deployments,nodes,pods,statefulsets,jobs,horizontalpodautoscalers,resourcequotas,cronjobs,replicasets
         ports:
         - name: metrics
           containerPort: 8080

--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
@@ -37,7 +37,6 @@ spec:
         - /kube-state-metrics
         - --port=8080
         - --telemetry-port=8081
-        - --collectors=deployments,pods,statefulsets,nodes,horizontalpodautoscalers
         ports:
         - name: metrics
           containerPort: 8080

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
         - --port=8080
         - --telemetry-port=8081
         - --kubeconfig=/etc/kube-state-metrics/config/kubeconfig
-        - --collectors=daemonsets,deployments,nodes,pods,statefulsets
+        - --collectors=daemonsets,deployments,nodes,pods,statefulsets,jobs,horizontalpodautoscalers,resourcequotas,cronjobs,replicasets
         volumeMounts:
         - name: kubeconfig
           mountPath: /etc/kube-state-metrics/config

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-prometheus-rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-prometheus-rules.yaml
@@ -1057,7 +1057,7 @@ groups:
       message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
       runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
     expr: |
-      kube_job_failed{job="kube-state-metrics"}  > 0
+      kube_job_status_failed{job="kube-state-metrics"}  > 0
     for: 15m
     labels:
       severity: warning

--- a/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
@@ -8,6 +8,8 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - secrets
   - nodes
   - pods
   - services
@@ -15,18 +17,29 @@ rules:
   - replicationcontrollers
   - limitranges
   - persistentvolumeclaims
+  - persistentvolumes
   - namespaces
+  - endpoints
   verbs:
   - list
   - watch
 - apiGroups:
-  - apps
   - extensions
   resources:
   - daemonsets
   - deployments
   - replicasets
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch
@@ -38,6 +51,63 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding

--- a/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
@@ -8,8 +8,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - secrets
   - nodes
   - pods
   - services
@@ -17,29 +15,18 @@ rules:
   - replicationcontrollers
   - limitranges
   - persistentvolumeclaims
-  - persistentvolumes
   - namespaces
-  - endpoints
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - ingresses
   verbs:
   - list
   - watch
 - apiGroups:
   - apps
+  - extensions
   resources:
-  - statefulsets
   - daemonsets
   - deployments
   - replicasets
+  - statefulsets
   verbs:
   - list
   - watch
@@ -55,55 +42,6 @@ rules:
   - autoscaling
   resources:
   - horizontalpodautoscalers
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  - volumeattachments
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
   verbs:
   - list
   - watch


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

1. collect more k8s object resources metrics
2. kube_job_failed => kube_job_status_failed, kube_job_status_failed have reason label for failed job

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
