### PR TITLE
shrink retention time of tsdb data and extend pvc size

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -81,8 +81,8 @@ spec:
         - --config.file=/etc/prometheus/config/prometheus.yaml
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.no-lockfile
-        - --storage.tsdb.retention.time=30d
-        - --storage.tsdb.retention.size=15GB
+        - --storage.tsdb.retention.time=4h
+        - --storage.tsdb.retention.size=25GB
         - --web.route-prefix=/
         - --web.enable-lifecycle
         - --web.listen-address=0.0.0.0:{{ .Values.port }}

--- a/charts/seed-monitoring/charts/core/values.yaml
+++ b/charts/seed-monitoring/charts/core/values.yaml
@@ -1,6 +1,6 @@
 prometheus:
   replicas: 1
-  storage: 20Gi
+  storage: 30Gi
   networks:
     pods: 100.96.0.0/11
     services: 100.64.0.0/13


### PR DESCRIPTION
1. shrink retention time of tsdb data to 4h
2. extend the size of prometheus pvc to 30GB

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
