### PR TITLE
fix illegal network policy

### DIFF
--- a/pkg/operation/common/network_policies_test.go
+++ b/pkg/operation/common/network_policies_test.go
@@ -61,4 +61,27 @@ var _ = Describe("networkpolicies", func() {
 			Expect(result).To(ConsistOf(expectedResult))
 		})
 	})
+
+	Describe("#ToExceptNetworks (k8s >= 1.18)", func() {
+		It("should totally exclude 192.168.0.0/16", func() {
+			result, err := ToExceptNetworks(AllPrivateNetworkBlocks(), "10.10.0.0/24", "172.16.1.0/24", "192.168.0.0/16", "100.64.1.0/24")
+			expectedResult := []interface{}{
+				map[string]interface{}{
+					"network": "10.0.0.0/8",
+					"except":  []string{"10.10.0.0/24"},
+				},
+				map[string]interface{}{
+					"network": "172.16.0.0/12",
+					"except":  []string{"172.16.1.0/24"},
+				},
+				map[string]interface{}{
+					"network": "100.64.0.0/10",
+					"except":  []string{"100.64.1.0/24"},
+				},
+			}
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ConsistOf(expectedResult))
+		})
+	})
 })


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

**What this PR does / why we need it**:

Fix a bug of Gardener that caused error when deploying network policy upon k8s >= 1.18

```
failed to apply manifests: 2 errors occurred: [could not apply object
      of kind "NetworkPolicy" "garden/allow-to-private-networks": NetworkPolicy.extensions
      "allow-to-private-networks" is invalid: spec.egress[0].to[2].ipBlock.except[0]:
      Invalid value: "192.168.0.0/16": must be a strict subset of `cidr`, could not
      apply object of kind "NetworkPolicy" "garden/allow-to-seed-apiserver": NetworkPolicy.extensions
      "allow-to-seed-apiserver" is invalid: spec.egress[0].to[3].ipBlock.except[0]:
      Invalid value: "192.168.0.0/16": must be a strict subset of `cidr`]'
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
