### PR TITLE
update vpa CRD and enlarge OSC wait

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
@@ -16,28 +16,55 @@ spec:
   version: v1beta1
   versions:
   - name: v1beta1
-    served: true
+    served: false
     storage: false
   - name: v1beta2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           required: []
           properties:
             targetRef:
               type: object
             updatePolicy:
+              type: object
               properties:
                 updateMode:
                   type: string
             resourcePolicy:
+              type: object
               properties:
                 containerPolicies:
                   type: array
+                  items:
+                    type: object
+                    properties:
+                      containerName:
+                        type: string
+                      controlledValues:
+                        type: string
+                        enum: ["RequestsAndLimits", "RequestsOnly"]
+                      mode:
+                        type: string
+                        enum: ["Auto", "Off"]
+                      minAllowed:
+                        type: object
+                      maxAllowed:
+                        type: object
+                      controlledResources:
+                        type: array
+                        items:
+                          type: string
+                          enum: ["cpu", "memory"]
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -57,8 +84,11 @@ spec:
   version: v1beta1
   versions:
   - name: v1beta1
-    served: true
+    served: false
     storage: false
   - name: v1beta2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -261,9 +261,10 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 			Fn:           flow.TaskFn(botanist.SyncShootCredentialsToGarden).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deploySecrets, initializeShootClients, deployKubeControllerManager),
 		})
+		// when worker group numbers are high, we need more time to wait OSC ready
 		computeShootOSConfig = g.Add(flow.Task{
 			Name:         "Computing operating system specific configuration for shoot workers",
-			Fn:           flow.TaskFn(botanist.ComputeShootOperatingSystemConfig).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(botanist.ComputeShootOperatingSystemConfig).RetryUntilTimeout(defaultInterval, 3*time.Minute),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilInfrastructureReady),
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -364,6 +364,7 @@ func (b *Botanist) applyAndWaitForShootOperatingSystemConfig(ctx context.Context
 
 	var osc *extensionsv1alpha1.OperatingSystemConfig
 
+	// when worker group numbers are high, we need more time to wait OSC ready
 	if err := common.WaitUntilExtensionCRReady(
 		ctx,
 		b.K8sSeedClient.Client(),
@@ -373,7 +374,7 @@ func (b *Botanist) applyAndWaitForShootOperatingSystemConfig(ctx context.Context
 		b.Shoot.SeedNamespace,
 		name,
 		DefaultInterval,
-		30*time.Second,
+		3*time.Minute,
 		func(obj runtime.Object) error {
 			o, ok := obj.(*extensionsv1alpha1.OperatingSystemConfig)
 			if !ok {


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

**What this PR does / why we need it**:

1. wait longer for OSC so that we can reconcile shoot with 50+ worker groups
2. update VPA crd definition so that we can use VPA >= v.0.8.0
